### PR TITLE
Allow parallel markers to be parametrised by process count

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,24 +19,103 @@ Writing a parallel test simply requires marking the test with the `parallel` mar
 def test_my_code_on_5_procs():
     ...
 
+@pytest.mark.parallel(5)  # the "nprocs" kwarg is optional
+def test_my_code_on_5_procs_again():
+    ...
+
 @pytest.mark.parallel  # run in parallel with the default number of processes (3)
 def test_my_code_on_3_procs():
     ...
+
+@pytest.mark.parallel()  # the brackets are optional
+def test_my_code_on_3_procs_again():
+    ...
 ```
 
-## How it works
+One can also mark a test with a sequence of values for `nprocs`:
 
-1. The user calls `pytest` (not `mpiexec -n <# proc> pytest`!). This launches the "parent" `pytest` process.
-2. This parent `pytest` process collects all the tests and then begins to run them.
-3. When a test is found with the `parallel` marker, rather than executing the function as before, a subprocess is forked calling `mpiexec -np <# proc> pytest this_specific_test_file.py::this_specific_test`. This produces `<# proc>` "child" `pytest` processes that execute the test together.
-4. If this terminates successfully then the test is assumed to have passed.
+```py
+@pytest.mark.parallel(nprocs=[1, 2, 3])  # run in parallel on 1, 2 and 3 processes
+def test_my_code_on_variable_nprocs():
+    ...
 
-## FAQs
+@pytest.mark.parallel([1, 2, 3])  # again the "nprocs" kwarg is optional
+def test_my_code_on_variable_nprocs_again():
+    ...
+```
 
-### Why call `mpiexec` internally instead of wrapping `pytest` in it?
+If multiple numbers of processes are requested then the tests are parametrised
+and renamed to, in this case, `test_my_code_on_variable_nprocs[nprocs=1]`,
+`test_my_code_on_variable_nprocs[nprocs=2]` and
+`test_my_code_on_variable_nprocs[nprocs=3]`.
 
-It is not a good idea to wrap `pytest` in an `mpiexec` because it would not compose well with various `pytest` plugins. In particular it would likely cause deadlocks when used with `pytest-xdist`.
+### Extra markers
 
-## Caveats
+When running the code with these `parallel` markers, `pytest-mpi` adds extra markers
+to each test to allow one to select all tests with a particular number of processors.
+For example, to select all parallel tests on 3 processors, one should run
 
-Unfortunately `pytest-mpi` will only work for MPI distributions that support nested calls to `MPI_Init` (e.g. [MPICH](https://www.mpich.org/)). This is because of step 3 above. The parent `pytest` needs to import all of the test scripts before tests can be run and, unless you have been extremely careful with your imports, it is very likely that a line like `from mpi4py import MPI` or `from petsc4py import PETSc` will be encountered and these will go away and call `MPI_Init`. Then, launching the child `pytest` processes with `mpiexec` will trigger another call to `MPI_Init`, breaking things.
+```bash
+$ pytest -m "parallel[3]"
+```
+
+For serial tests - those either unmarked or marked `@pytest.mark.parallel(1)` - one
+can select these by running
+
+```bash
+$ pytest -m "not parallel or parallel[1]"
+```
+
+### Forking mode
+
+`pytest-mpi` can be run in one of two modes: forking or non-forking. The former
+works as follows:
+
+1. The user calls `pytest` (not `mpiexec -n <# proc> pytest`!). This launches
+   the "parent" `pytest` process.
+2. This parent `pytest` process collects all the tests and begins to run them.
+3. When a test is found with the `parallel` marker, rather than executing the
+   function as before, a subprocess is forked calling
+   `mpiexec -np <# proc> pytest this_specific_test_file.py::this_specific_test`.
+   This produces `<# proc>` "child" `pytest` processes that execute the
+   test together.
+4. If this terminates successfully then the test is considered to have passed.
+
+This is convenient for development for a number of reasons:
+
+* The plugin composes better with other pytest plugins like `pytest-xdist`.
+* It is not necessary to wrap `pytest` invocations with `mpiexec` calls, and
+  all parallel and serial tests can be run at once.
+
+However, the forking mode of `pytest-mpi` is restricted in that only one mainstream
+MPI distribution ([MPICH](https://www.mpich.org/)) supports nested calls to
+`MPI_Init`. If your "parent" `pytest` process initialises MPI (for instance by
+executing `from petsc4py import PETSc`) then this will cause non-MPICH MPI
+distributions to crash. Further, forking a subprocess can be expensive since a
+completely fresh Python interpreter is launched each time.
+
+### Non-forking mode
+
+With these significant limitations in mind, `pytest-mpi` therefore also supports
+a non-forking mode. To use it, one simply needs to wrap the `pytest` invocation
+with `mpiexec`, no additional configuration is necessary. For example, to run
+all of the parallel tests on 2 ranks one needs to execute:
+
+```bash
+$ mpiexec -n 2 pytest -m "parallel[2]"
+```
+
+This approach is agnostic to MPI distribution, and free from the forking startup
+overhead, but has a number of disadvantages:
+
+* `pytest-xdist` is strictly disallowed as threading would lead to deadlocks. It
+  is therefore impossible to take full advantage of machines with many cores.
+* A different `mpiexec` instruction is required for each level of parallelism.
+  Attempting to run with `mpiexec` with a mismatching number of processes to the
+  parallel marker will result in an error.
+
+## Configuration
+
+`pytest-mpi` respects the environment variable `PYTEST_MPI_MAX_NPROCS`, which defines
+the maximum number of processes that can be requested by a parallel marker. If this
+value is exceeded an error will be raised.

--- a/pytest_mpi.py
+++ b/pytest_mpi.py
@@ -1,8 +1,9 @@
+import collections
 import os
 import subprocess
 
-from mpi4py import MPI
 import pytest
+from mpi4py import MPI
 
 
 CHILD_PROCESS_FLAG = "_PYTEST_MPI_CHILD_PROCESS"
@@ -16,13 +17,38 @@ def pytest_configure(config):
     )
 
 
+def pytest_generate_tests(metafunc):
+    """Identify tests with parallel markers and break them apart if necessary.
+
+    This hook turns tests with marks like ``@pytest.mark.parallel([2, 3, 4])``
+    into multiple tests, one for each requested size. The tests are then
+    distinguished by ID. For example ``test_abc[nprocs=2]``, ``test_abc[nprocs=3]``
+    and ``test_abc[nprocs=4]``. If only one parallel size is requested then this
+    is skipped.
+
+    """
+    markers = tuple(m for m in metafunc.function.pytestmark if m.name == "parallel")
+
+    if not markers:
+        return
+
+    marker, = markers
+    nprocs = _parse_nprocs(marker)
+    # Only label tests if more than one parallel size is requested
+    if len(nprocs) > 1:
+        # Trick the function into thinking that it needs an extra fixture argument
+        metafunc.fixturenames.append("_nprocs")
+        metafunc.parametrize("_nprocs", nprocs, ids=lambda n: f"nprocs={n}")
+
+
 @pytest.hookimpl(trylast=True)
 def pytest_collection_modifyitems(config, items):
     using_parallel_markers = any(item.get_closest_marker("parallel") for item in items)
     if using_parallel_markers and MPI.COMM_WORLD.size > 1 and not _is_parallel_child_process():
         raise pytest.UsageError(
             "pytest should not be called from within a parallel context "
-            "(e.g. mpiexec -n 3 pytest ...)")
+            "(e.g. mpiexec -n 3 pytest ...)"
+        )
 
 
 def pytest_runtest_setup(item):
@@ -37,28 +63,66 @@ def _is_parallel_child_process():
 def _set_parallel_callback(item):
     """Replace the callback for a test item with one that calls ``mpiexec``.
 
+    If the number of processes requested is 1 then this function does nothing.
+
     Parameters
     ----------
     item : _pytest.nodes.Item
         The test item to run.
+
     """
-    nprocs = item.get_closest_marker("parallel").kwargs.get("nprocs", 3)
-    if nprocs < 2:
-        raise pytest.UsageError("Need to specify at least two processes for a parallel test")
+    # First check to see if we have parametrised nprocs (if multiple were requested)
+    if hasattr(item, "callspec") and "_nprocs" in item.callspec.params:
+        nprocs = item.callspec.params["_nprocs"]
+    else:
+        # The parallel marker must just want one value of nprocs
+        marker = item.get_closest_marker("parallel")
+        nprocs, = _parse_nprocs(marker)
+
+    if nprocs == 1:
+        return
 
     # Run xfailing tests to ensure that errors are reported to calling process
     pytest_args = ["--runxfail", "-s", "-q", f"{item.fspath}::{item.name}"]
     # Try to generate less output on other ranks so stdout is easier to read
-    quieter_pytest_args = (pytest_args
-                           + ["--tb=no", "--no-summary", "--no-header",
-                              "--disable-warnings", "--show-capture=no"])
+    quieter_pytest_args = pytest_args + [
+        "--tb=no", "--no-summary", "--no-header",
+        "--disable-warnings", "--show-capture=no"
+    ]
 
-    cmd = (["mpiexec", "-n", "1", "-genv", CHILD_PROCESS_FLAG, "1", "python", "-m", "pytest"]
-            + pytest_args
-            + [":", "-n", f"{nprocs-1}", "python", "-m", "pytest"]
-            + quieter_pytest_args)
+    cmd = [
+        "mpiexec", "-n", "1", "-genv", CHILD_PROCESS_FLAG, "1", "python", "-m", "pytest"
+    ] + pytest_args + [
+        ":", "-n", f"{nprocs-1}", "python", "-m", "pytest"
+    ] + quieter_pytest_args
 
     def parallel_callback(*args, **kwargs):
-         subprocess.run(cmd, check=True)
+        subprocess.run(cmd, check=True)
 
     item.obj = parallel_callback
+
+
+def _parse_nprocs(marker):
+    """Return the number of processes requested from a parallel marker.
+
+    This function enables one to use the parallel marker with or without
+    using the ``nprocs`` keyword argument.
+
+    The returned process counts are provided as a tuple, even if only a
+    single value is requested.
+
+    """
+    assert marker.name == "parallel"
+
+    if len(marker.args) == 1 and not marker.kwargs:
+        return _as_tuple(marker.args[0])
+    elif len(marker.kwargs) == 1 and not marker.args:
+        return _as_tuple(marker.kwargs["nprocs"])
+    elif not marker.args and not marker.kwargs:
+        return (3,)
+    else:
+        raise pytest.UsageError("Bad arguments given to parallel marker")
+
+
+def _as_tuple(arg):
+    return tuple(arg) if isinstance(arg, collections.abc.Iterable) else (arg,)

--- a/pytest_mpi.py
+++ b/pytest_mpi.py
@@ -51,7 +51,11 @@ def pytest_generate_tests(metafunc):
     is skipped.
 
     """
-    markers = tuple(m for m in metafunc.function.pytestmark if m.name == "parallel")
+    markers = tuple(
+        m
+        for m in getattr(metafunc.function, "pytestmark", ())
+        if m.name == "parallel"
+    )
 
     if not markers:
         return


### PR DESCRIPTION
This lets us do things like

```py
@pytest.mark.parallel(3)  # don't need to say nprocs=3
```
and, more excitingly
```py
@pytest.mark.parallel([2, 3, 4])
test_abc():
    ...
```

What this code does is parametrise these tests upon collection, so `pytest --co` would yield
```
test_abc[nprocs=2]
test_abc[nprocs=3]
test_abc[nprocs=4]
```

Also, this code adds parallel markers (thanks to @JDBetteridge for the code) to the parallel tests so we can select tests that only run with a particular number of processes. E.g. `-m "parallel[3]"`.

This appears to work locally, but I want to do more testing before merging, hence marking as draft for now.

@JHopeCollins you may find this interesting.