### PR TITLE
Add editables packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "editables"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
`editables` is required for an editable install.

Not sure it's 100% essential for any other install.